### PR TITLE
chore: release v0.1.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.2](https://github.com/security-union/webtranscat/compare/v0.1.1...v0.1.2) - 2025-07-20
+
+### Other
+
+- Fix link to repo ([#3](https://github.com/security-union/webtranscat/pull/3))
+
 ## [0.1.0](https://github.com/security-union/webtranscat/releases/tag/v0.1.0) - 2025-07-18
 
 ### Other

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1699,7 +1699,7 @@ dependencies = [
 
 [[package]]
 name = "webtranscat"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "anyhow",
  "aws-lc-rs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "webtranscat"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2021"
 description = "WebTransport equivalent of websocat - a command-line WebTransport client for debugging and testing"
 authors = ["dario@securityunion.dev"]


### PR DESCRIPTION



## 🤖 New release

* `webtranscat`: 0.1.1 -> 0.1.2

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.1.2](https://github.com/security-union/webtranscat/compare/v0.1.1...v0.1.2) - 2025-07-20

### Other

- Fix link to repo ([#3](https://github.com/security-union/webtranscat/pull/3))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).